### PR TITLE
Remove CommonMiddleware from MIDDLEWARE_CLASSES.

### DIFF
--- a/hello.py
+++ b/hello.py
@@ -11,9 +11,7 @@ settings.configure(
     DEBUG = True,
     SECRET_KEY = 'yourrandomsecretkey',
     ROOT_URLCONF = __name__,
-    MIDDLEWARE_CLASSES = (
-        'django.middleware.common.CommonMiddleware',
-    ),
+    MIDDLEWARE_CLASSES = (),
 )
 
 """


### PR DESCRIPTION
`CommonMiddleware` isn't required for Django to run. Lightened up this example by making `MIDDLEWARE_CLASSES` an empty tuple.
